### PR TITLE
Add semantic triage Google Apps Script sample

### DIFF
--- a/samples/semantic_triage.js
+++ b/samples/semantic_triage.js
@@ -1,0 +1,77 @@
+/**
+ * Pseudo-código para un disparador de triaje semántico
+ *
+ * This script is intended to be used in Google Apps Script (GAS).
+ * It demonstrates a semantic triage trigger that analyzes incoming emails
+ * using a hypothetical AgentJules (wrapping Gemini) and sends notifications
+ * for dissatisfied customers.
+ */
+
+/**
+ * Trigger function for new emails.
+ * Note: In a real GAS environment, you would likely use a time-driven trigger
+ * to poll for new threads, as 'onNewEmail' is not a direct simple trigger
+ * that passes the event object with thread details in this manner.
+ *
+ * @param {Object} e - The event object (conceptually).
+ */
+function onNewEmailTrigger(e) {
+  // In a real scenario, you might retrieve threads like:
+  // const threads = GmailApp.search('is:unread');
+  // and iterate over them. Here we follow the pseudo-code structure.
+
+  const thread = e.thread;
+  const analysis = AgentJules.analyzeWithGemini(thread.getLatestMessage().getBody()); // Invocación lógica
+
+  if (analysis.sentiment < 0.3) {
+    NotificationService.sendToChat("⚠️ Cliente insatisfecho detectado: " + thread.getId());
+  }
+}
+
+/**
+ * Mock class representing the AgentJules service.
+ */
+class AgentJules {
+  /**
+   * Analyzes the text using Gemini.
+   * @param {string} text - The text to analyze.
+   * @returns {Object} Analysis result containing sentiment.
+   */
+  static analyzeWithGemini(text) {
+    console.log("Analyzing text with Gemini:", text.substring(0, 50) + "...");
+    // Mock implementation: random sentiment for demonstration
+    // In production, this would call the Gemini API via UrlFetchApp.
+    return {
+      sentiment: Math.random(), // Returns a value between 0 and 1
+      summary: "Analysis complete"
+    };
+  }
+}
+
+/**
+ * Mock class representing the NotificationService.
+ */
+class NotificationService {
+  /**
+   * Sends a message to a chat service.
+   * @param {string} message - The message to send.
+   */
+  static sendToChat(message) {
+    console.log("Sending notification:", message);
+    // In production, this would make a POST request to a Chat webhook.
+  }
+}
+
+// Example usage for testing locally (if run in a JS environment)
+if (typeof module !== 'undefined' && module.exports) {
+    // Mock the thread object for local testing
+    const mockThread = {
+        getId: () => "thread-123",
+        getLatestMessage: () => ({
+            getBody: () => "I am very unhappy with this service!"
+        })
+    };
+
+    // Simulate the trigger
+    onNewEmailTrigger({ thread: mockThread });
+}


### PR DESCRIPTION
Added `samples/semantic_triage.js` which implements the requested pseudo-code for analyzing email sentiment using a mock AgentJules service. This script is intended to be used as a reference for Google Apps Script integrations.